### PR TITLE
refactor(changelog): migrate from versioned to date-based format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [2025-08-22]
 
 ### Changed
+- refactor(mcp): optimize GitHub MCP configuration with minimal verbosity (PR #136)
+- docs(agents): integrate agent ecosystem across workflow and configuration (PR #135)
+- docs(workflow): improve UX flow and integrate worktree management (PR #133)
+- docs(workflow): improve session-start command and configuration management (PR #132)
 - feat(workflow): separate changelog management from switch command (PR #131)
 - docs: update workflow documentation and add CHANGELOG (PR #130)
 
-## [1.0.0] - 2025-01-14
+## [2025-01-14]
 
 ### Added
 - Initial master orchestrator implementation
@@ -25,5 +28,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Migrated from manual to automated deployment workflows
 
-[unreleased]: https://github.com/GLab-Projects/trivance-ai-orchestrator/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/GLab-Projects/trivance-ai-orchestrator/releases/tag/v1.0.0


### PR DESCRIPTION
## What Changed
- Migrate CHANGELOG format from [Unreleased] to date-based sections
- Simplify changelog command from bash scripts to natural language
- Remove semantic versioning references for non-versioned project

## Test Plan
- [x] Command executes without errors
- [x] Feature works as expected  
- [x] No breaking changes

## Breaking Changes
None